### PR TITLE
Add Wifi Firmware for Raspbery Pi

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -10,7 +10,7 @@ CLEAN_FILES = $(TAG)
 ARMBIAN_FIRMWARE_PKG = armbian-firmware
 
 # firmware for wifi dongle (note, some overlap with armbian-firmware)
-RASPBIAN_FIRMWARE_PKG = firmware-ralink
+RASPBIAN_FIRMWARE_PKG = firmware-brcm80211 firmware-ralink firmware-atheros
 
 # Directories
 ARMBIAN = $(BUILD)/armbian

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -50,7 +50,7 @@ $(TAG)/raspbian:
 $(BUILD)/firmware-raspbian.cpio: $(TAG)/raspbian
 	( \
             cd $(RASPBIAN); \
-	    find lib/firmware/brcm -maxdepth 1 -type f ! -name "brcmfmac43430-sdio.*" -delete; \
+            find lib/firmware/brcm -maxdepth 1 -type f ! -name "brcmfmac43430-sdio.*" -delete; \
             find lib/firmware -print0 | cpio -0 -H newc -R 0:0 -o \
 	) > $@
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -50,6 +50,7 @@ $(TAG)/raspbian:
 $(BUILD)/firmware-raspbian.cpio: $(TAG)/raspbian
 	( \
             cd $(RASPBIAN); \
+	    find lib/firmware/brcm -maxdepth 1 -type f ! -name "brcmfmac43430-sdio.*" -delete; \
             find lib/firmware -print0 | cpio -0 -H newc -R 0:0 -o \
 	) > $@
 


### PR DESCRIPTION
Still need to clean up unneeded firmware,
any suggestions on how to gut it

IE brcm is 4 megs but only  ~370k is needed 
(brcmfmac43430-sdio.bin and brcmfmac43430-sdio.txt)

```
root@ramdisk-0a27945f:~# ls -lah /lib/firmware/brcm/
total 4.2M
drwxr-xr-x 2 root root  320 Aug  9  2017 .
drwxr-xr-x 5 root root  480 Jan 23  2018 ..
-rw-r--r-- 1 root root  94K Aug  9  2017 bcm43xx-0.fw
-rw-r--r-- 1 root root  180 Aug  9  2017 bcm43xx_hdr-0.fw
-rw-r--r-- 1 root root 377K Aug  9  2017 brcmfmac43143-sdio.bin
-rw-r--r-- 1 root root 388K Aug  9  2017 brcmfmac43143.bin
-rw-r--r-- 1 root root 446K Aug  9  2017 brcmfmac43241b0-sdio.bin
-rw-r--r-- 1 root root 395K Aug  9  2017 brcmfmac43241b4-sdio.bin
-rw-r--r-- 1 root root 248K Aug  9  2017 brcmfmac4329-sdio.bin
-rw-r--r-- 1 root root 217K Aug  9  2017 brcmfmac4330-sdio.bin
-rw-r--r-- 1 root root 441K Aug  9  2017 brcmfmac4334-sdio.bin
-rw-r--r-- 1 root root 556K Aug  9  2017 brcmfmac4335-sdio.bin
-rw-r--r-- 1 root root 215K Aug  9  2017 brcmfmac43362-sdio.bin
-rw-r--r-- 1 root root 364K Aug  9  2017 brcmfmac43430-sdio.bin
-rw-r--r-- 1 root root 1014 Aug  9  2017 brcmfmac43430-sdio.txt
-rw-r--r-- 1 root root 496K Aug  9  2017 brcmfmac4354-sdio.bin
```