### PR TITLE
Fix space after raspberrypi3 causing cp error

### DIFF
--- a/boards/raspberrypi2/Makefile
+++ b/boards/raspberrypi2/Makefile
@@ -6,7 +6,7 @@ DEBIAN_VER = stretch
 DEBIAN_ARCH = armhf
 
 BOARD = raspberrypi2
-BOARD_ALIAS = raspberrypi3 # try to avoid questions
+BOARD_ALIAS = raspberrypi3
 
 RASPBIAN_BOOT_PKG = raspberrypi-bootloader
 RASPBIAN_KERNEL_PKG = raspberrypi-kernel

--- a/boards/raspberrypi2/Makefile
+++ b/boards/raspberrypi2/Makefile
@@ -6,6 +6,8 @@ DEBIAN_VER = stretch
 DEBIAN_ARCH = armhf
 
 BOARD = raspberrypi2
+
+# raspberrypi3 uses the same image but making a copy to avoid confusion
 BOARD_ALIAS = raspberrypi3
 
 RASPBIAN_BOOT_PKG = raspberrypi-bootloader


### PR DESCRIPTION
```
mkdir -p /home/benedict/projects/mesh-orange/output/
cp build/disk.img /home/benedict/projects/mesh-orange/output/raspberrypi2.img
cp build/disk.img /home/benedict/projects/mesh-orange/output/raspberrypi3 .img
cp: target '.img' is not a directory
```