### PR TITLE
re-build speed improvements, update the debian submodule

### DIFF
--- a/boards/qemu_armhf/Makefile
+++ b/boards/qemu_armhf/Makefile
@@ -23,7 +23,12 @@ image:
 	echo as a virtual system, there is no way to build an image
 	false
 
-test: $(LOCAL_KERNEL) $(BUILD)/combined.initrd
+$(BUILD): $(TAG)/build
+$(TAG)/build:
+	mkdir -p $(BUILD)
+	$(call tag,build)
+
+test: $(LOCAL_KERNEL) $(TAG)/build $(BUILD)/combined.initrd
 	qemu-system-arm -M virt \
 		-m 512 \
 		-kernel $(LOCAL_KERNEL) \

--- a/boards/raspberrypi2/Makefile
+++ b/boards/raspberrypi2/Makefile
@@ -68,9 +68,6 @@ $(TAG)/boot:
 	mkdir -p $(BOOT)
 	$(call tag,boot)
 
-$(BOOT)/kernel7.img: $(TAG)/boot $(TAG)/raspberrypi
-	cp $(RASPBERRYPI)/boot/kernel7.img $@
-
 $(BOOT)/initrd: $(TAG)/boot
 $(BOOT)/initrd: $(BUILD)/combined.initrd
 	cp $< $@
@@ -94,20 +91,12 @@ $(BOOT)/%: $(RASPBERRYPI)/boot/% $(TAG)/boot
 $(RASPBERRYPI)/boot/bootcode.bin: $(TAG)/raspberrypi
 $(RASPBERRYPI)/boot/fixup_cd.dat: $(TAG)/raspberrypi
 $(RASPBERRYPI)/boot/start_cd.elf: $(TAG)/raspberrypi
+$(RASPBERRYPI)/boot/kernel7.img: $(TAG)/raspberrypi
 $(RASPBERRYPI)/boot/COPYING.linux: $(TAG)/raspberrypi
 $(RASPBERRYPI)/boot/LICENCE.broadcom: $(TAG)/raspberrypi
 $(RASPBERRYPI)/boot/bcm2709-rpi-2-b.dtb: $(TAG)/raspberrypi
 $(RASPBERRYPI)/boot/bcm2710-rpi-3-b.dtb: $(TAG)/raspberrypi
 $(RASPBERRYPI)/boot/bcm2710-rpi-cm3.dtb: $(TAG)/raspberrypi
-
-$(BOOT)/bootcode.bin: $(RASPBERRYPI)/boot/bootcode.bin
-$(BOOT)/fixup_cd.dat: $(RASPBERRYPI)/boot/fixup_cd.dat
-$(BOOT)/start_cd.elf: $(RASPBERRYPI)/boot/start_cd.elf
-$(BOOT)/COPYING.linux: $(RASPBERRYPI)/boot/COPYING.linux
-$(BOOT)/LICENCE.broadcom: $(RASPBERRYPI)/boot/LICENCE.broadcom
-$(BOOT)/bcm2709-rpi-2-b.dtb: $(RASPBERRYPI)/boot/bcm2709-rpi-2-b.dtb
-$(BOOT)/bcm2710-rpi-3-b.dtb: $(RASPBERRYPI)/boot/bcm2710-rpi-3-b.dtb
-$(BOOT)/bcm2710-rpi-cm3.dtb: $(RASPBERRYPI)/boot/bcm2710-rpi-cm3.dtb
 
 BOOT_FILES = \
     $(BOOT)/bootcode.bin \

--- a/boards/raspberrypi2/Makefile
+++ b/boards/raspberrypi2/Makefile
@@ -14,9 +14,8 @@ RASPBIAN_BOOT_PKG = raspberrypi-bootloader
 RASPBIAN_KERNEL_PKG = raspberrypi-kernel
 
 INITRD_PARTS += $(BUILD)/modules.lzma
-CLEAN_FILES += $(BUILD)/modules.lzma
 
-CLEAN_FILES += $(TAG) $(RASPBERRYPI) $(BOOT)
+CLEAN_FILES += $(TAG)
 
 # Directories
 RASPBERRYPI = $(BUILD)/raspberrypi

--- a/boards/sun8i-v3s-licheepi-zero/Makefile
+++ b/boards/sun8i-v3s-licheepi-zero/Makefile
@@ -22,6 +22,9 @@ PART3_SIZE_MEGS = 500 # ext2 root
 
 CLEAN_FILES = $(TAG) $(ZIP) $(BOOT) $(BUILD)/root.fs.tmp
 
+ZERO_FIRMWARE = $(BUILD)/zero_firmware.cpio
+INITRD_PARTS += $(ZERO_FIRMWARE)
+
 # Directories
 ZIP = $(BUILD)/zero_imager
 
@@ -51,6 +54,13 @@ $(BUILD)/zero_imager.zip:
 
 $(ZIP): $(BUILD)/zero_imager.zip
 	unzip -o $(BUILD)/zero_imager.zip -d $(BUILD)
+
+$(ZERO_FIRMWARE): $(ZIP)
+	( \
+	    cd $</overlay_rootfs-base/; \
+	    find lib/firmware -print0 | cpio -0 -H newc -R 0:0 -o \
+	) >$@
+CLEAN_FILES += $(ZERO_FIRMWARE)
 
 $(BUILD)/root.fs: $(DEBIAN).cpio $(LOCAL_MODULES_CPIO) $(ZIP)
 	truncate --size=$$(( $(PART3_SIZE_MEGS)*1 ))M $@.tmp

--- a/debian-config/.gitignore
+++ b/debian-config/.gitignore
@@ -1,0 +1,3 @@
+
+# Ignore the dependancies file that the debian builder automatically creates
+.configdir.deps

--- a/docs/boot-1.dot
+++ b/docs/boot-1.dot
@@ -5,6 +5,8 @@
 #
 
 digraph g{
+    rankdir=LR;
+
     power_on -> spl;
     spl -> uboot_config;
 

--- a/docs/build.dot
+++ b/docs/build.dot
@@ -9,15 +9,17 @@ digraph g{
         graph[style=dotted];
         color=blue;
 
+        debian_minimal_builder -> debian_minimal_builder_repo [dir=none style=invisible];
+        debian_minimal_builder -> local_overrides [dir=none style=invisible];
+
         debian_minimal_builder_repo [shape=folder];
         local_overrides [shape=note];
         minimal_initrd [shape=box3d];
 
-        debian_minimal_builder_repo -> makefile;
+        debian_minimal_builder_repo -> minimal_initrd;
 
-        local_overrides -> makefile;
+        local_overrides -> minimal_initrd;
 
-        makefile -> minimal_initrd;
     }
     
     subgraph cluster_kernel {

--- a/docs/build.dot
+++ b/docs/build.dot
@@ -60,8 +60,8 @@ digraph g{
 
         initrd [shape=box3d];
         conf_d [label="conf.d" shape=folder];
-        spl [shape=note];
-        uboot [shape=note];
+        spl [shape=box3d];
+        uboot [shape=box3d];
         uboot_config [shape=folder];
 
         spl -> disk_image;

--- a/docs/build.dot
+++ b/docs/build.dot
@@ -49,9 +49,9 @@ digraph g{
         github_release -> dtb;
     }
 
-    armbian_firmware [shape=folder];
+    upstream_firmware [shape=folder];
     firmware [shape=folder];
-    armbian_firmware -> firmware;
+    upstream_firmware -> firmware;
 
     cjdns_deb [shape=folder];
     cjdns_extract [shape=folder];

--- a/docs/build.dot
+++ b/docs/build.dot
@@ -14,11 +14,11 @@ digraph g{
 
         debian_minimal_builder_repo [shape=folder];
         local_overrides [shape=note];
-        minimal_initrd [shape=box3d];
+        userspace_initrd [shape=box3d];
 
-        debian_minimal_builder_repo -> minimal_initrd;
+        debian_minimal_builder_repo -> userspace_initrd;
 
-        local_overrides -> minimal_initrd;
+        local_overrides -> userspace_initrd;
 
     }
     
@@ -73,7 +73,7 @@ digraph g{
     }
 
     firmware -> initrd;
-    minimal_initrd -> initrd;
+    userspace_initrd -> initrd;
     modules -> initrd;
     cjdns_extract -> initrd;
     kernel_image -> disk_image;

--- a/docs/build.dot
+++ b/docs/build.dot
@@ -24,20 +24,11 @@ digraph g{
         graph[style=dotted];
         color=blue;
 
-        kernel_config [shape=note];
-        mainline_source [shape=folder];
-        kernel_patches [shape=folder];
-        kernel_source [shape=folder];
         kernel_image [shape=box3d];
         modules [shape=folder];
         dtb [shape=folder];
 
-        kernel_patches -> kernel_source;
-        mainline_source -> kernel_source;
-        kernel_source -> kernel_build;
-        kernel_config -> kernel_build;
-
-        kernel_build -> github_release -> kernel_image;
+        github_release -> kernel_image;
         github_release -> modules;
         github_release -> dtb;
     }

--- a/docs/build.dot
+++ b/docs/build.dot
@@ -5,25 +5,19 @@
 digraph g{
 
     subgraph cluster_debian {
-        debian [shape=plaintext];
+        debian_minimal_builder [shape=plaintext];
         graph[style=dotted];
         color=blue;
 
-        debian_repo [shape=folder];
-        package_list [shape=note];
-        delete_list [shape=note];
-        fixup_list [shape=note];
-        add_files [shape=note];
-        debian_initrd [shape=box3d];
+        debian_minimal_builder_repo [shape=folder];
+        local_overrides [shape=note];
+        minimal_initrd [shape=box3d];
 
-        debian_repo -> multistrap -> minimise -> fixup -> customise;
+        debian_minimal_builder_repo -> makefile;
 
-        package_list -> multistrap;
-        delete_list -> minimise;
-        fixup_list -> fixup;
-        add_files -> customise;
+        local_overrides -> makefile;
 
-        customise -> debian_initrd;
+        makefile -> minimal_initrd;
     }
     
     subgraph cluster_kernel {
@@ -77,7 +71,7 @@ digraph g{
     }
 
     firmware -> initrd;
-    debian_initrd -> initrd;
+    minimal_initrd -> initrd;
     modules -> initrd;
     cjdns_extract -> initrd;
     kernel_image -> disk_image;

--- a/docs/build.dot
+++ b/docs/build.dot
@@ -5,18 +5,15 @@
 digraph g{
 
     subgraph cluster_debian {
-        debian_minimal_builder [shape=plaintext];
+        debian [shape=plaintext];
         graph[style=dotted];
         color=blue;
 
-        debian_minimal_builder -> debian_minimal_builder_repo [dir=none style=invisible];
-        debian_minimal_builder -> local_overrides [dir=none style=invisible];
-
-        debian_minimal_builder_repo [shape=folder];
+        debian_submodule [shape=folder];
         local_overrides [shape=note];
         userspace_initrd [shape=box3d];
 
-        debian_minimal_builder_repo -> userspace_initrd;
+        debian_submodule -> userspace_initrd;
 
         local_overrides -> userspace_initrd;
 

--- a/docs/debian_minimal_builder.dot
+++ b/docs/debian_minimal_builder.dot
@@ -1,0 +1,37 @@
+#
+# Outline how the build process works
+#
+
+digraph g{
+    package_repo [shape=folder];
+    package_list [shape=note];
+    multistrap_template [shape=note];
+    multistrap_conf [shape=note];
+    delete_list [shape=note];
+    fixup_scripts [shape=note];
+    add_files [shape=note];
+    minimal_initrd [shape=box3d];
+
+    package_repo -> multistrap -> minimise -> fixup -> customise;
+
+    multistrap_template -> multistrap_conf;
+    package_list -> multistrap_conf;
+    multistrap_conf -> multistrap;
+    delete_list -> minimise;
+    fixup_scripts -> fixup;
+    add_files -> customise;
+
+    customise -> minimal_initrd;
+
+    external_package_list [shape=note color=blue];
+    replace_multistrap_template [shape=note color=blue];
+    external_fixup_scripts [shape=note color=blue];
+    external_add_files [shape=note color=blue];
+
+    external_package_list -> multistrap_conf;
+    replace_multistrap_template -> multistrap_conf;
+    external_fixup_scripts -> fixup;
+    external_add_files -> customise;
+    
+}
+

--- a/docs/debian_minimal_builder.dot
+++ b/docs/debian_minimal_builder.dot
@@ -10,7 +10,7 @@ digraph g{
     delete_list [shape=note];
     fixup_scripts [shape=note];
     add_files [shape=note];
-    minimal_initrd [shape=box3d];
+    userspace_initrd [shape=box3d];
 
     package_repo -> multistrap -> minimise -> fixup -> customise;
 
@@ -21,7 +21,7 @@ digraph g{
     fixup_scripts -> fixup;
     add_files -> customise;
 
-    customise -> minimal_initrd;
+    customise -> userspace_initrd;
 
     external_package_list [shape=note color=blue];
     replace_multistrap_template [shape=note color=blue];

--- a/docs/kernel.dot
+++ b/docs/kernel.dot
@@ -1,0 +1,25 @@
+#
+# Outline how the build process works
+#
+
+digraph g{
+
+    kernel_config [shape=note];
+    mainline_source [shape=folder];
+    kernel_patches [shape=folder];
+    kernel_source [shape=folder];
+    kernel_image [shape=box3d];
+    modules [shape=folder];
+    dtb [shape=folder];
+
+    kernel_patches -> kernel_source;
+    mainline_source -> kernel_source;
+    kernel_source -> kernel_build;
+    kernel_config -> kernel_build;
+
+    kernel_build -> github_release -> kernel_image;
+    github_release -> modules;
+    github_release -> dtb;
+
+}
+

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -26,9 +26,10 @@ $(TAG)/build-depends: Makefile
 	$(call tag,build-depends)
 
 # Rules to go and make the debian installed root
-# Note: this has no dependancy checking, and will simply use what ever
-# file is there
-$(DEBIAN).cpio: $(TOP_DIR)/debian/Makefile
+# Note: as this has no local dependency checks, we force it to always
+# run the make command, so the debian submodule can do some checks.
+.FORCE:
+$(DEBIAN).cpio: $(TOP_DIR)/debian/Makefile .FORCE
 	$(MAKE) -C $(TOP_DIR)/debian build/$(DEBIAN_BASENAME).cpio CONFIG_DEBIAN_ARCH=$(DEBIAN_ARCH)
 
 # Ensure that the submodule is actually present


### PR DESCRIPTION
Includes:
- improve graphviz docs
- Add dependancy checking to any scripts or extra files added to the debian build (thus allowing triggering faster rebuilds than just 'make clean')
- Add some modules and disk settle scripts to the debian build - to try and find block devices.

( Some of this work prompted by #32 )