### PR TITLE
Allow kernel to use tmpfs

### DIFF
--- a/boards/sun4i-a10-cubieboard/boot.cmd
+++ b/boards/sun4i-a10-cubieboard/boot.cmd
@@ -5,12 +5,10 @@
 
 # default values
 setenv load_addr "0x44000000"
-setenv rootdev "/dev/mmcblk0p1"
 setenv verbosity "1"
 setenv console "both"
 setenv disp_mem_reserves "off"
 setenv disp_mode "1920x1080p60"
-setenv rootfstype "ext4"
 
 # Print boot source
 itest.b *0x28 == 0x00 && echo "U-boot loaded from SD"
@@ -30,7 +28,7 @@ if test "${console}" = "serial" || test "${console}" = "both"; then setenv conso
 # mmc 0 is always mapped to device u-boot (2016.09+) was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc 0:1 partuuid; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
+setenv bootargs "${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
 
 if test "${disp_mem_reserves}" = "off"; then setenv bootargs "${bootargs} sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16"; fi
 

--- a/boards/sun7i-a20-bananapi/boot.cmd
+++ b/boards/sun7i-a20-bananapi/boot.cmd
@@ -5,12 +5,10 @@
 
 # default values
 setenv load_addr "0x44000000"
-setenv rootdev "/dev/mmcblk0p1"
 setenv verbosity "1"
 setenv console "both"
 setenv disp_mem_reserves "off"
 setenv disp_mode "1920x1080p60"
-setenv rootfstype "ext4"
 
 # Print boot source
 itest.b *0x28 == 0x00 && echo "U-boot loaded from SD"
@@ -30,7 +28,7 @@ if test "${console}" = "serial" || test "${console}" = "both"; then setenv conso
 # mmc 0 is always mapped to device u-boot (2016.09+) was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc 0:1 partuuid; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
+setenv bootargs "${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
 
 if test "${disp_mem_reserves}" = "off"; then setenv bootargs "${bootargs} sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16"; fi
 

--- a/boards/sun8i-h2-plus-orangepi-zero/boot.cmd
+++ b/boards/sun8i-h2-plus-orangepi-zero/boot.cmd
@@ -5,12 +5,10 @@
 
 # default values
 setenv load_addr "0x44000000"
-setenv rootdev "/dev/mmcblk0p1"
 setenv verbosity "1"
 setenv console "both"
 setenv disp_mem_reserves "off"
 setenv disp_mode "1920x1080p60"
-setenv rootfstype "ext4"
 
 # Print boot source
 itest.b *0x28 == 0x00 && echo "U-boot loaded from SD"
@@ -30,7 +28,7 @@ if test "${console}" = "serial" || test "${console}" = "both"; then setenv conso
 # mmc 0 is always mapped to device u-boot (2016.09+) was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc 0:1 partuuid; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
+setenv bootargs "${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
 
 if test "${disp_mem_reserves}" = "off"; then setenv bootargs "${bootargs} sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16"; fi
 

--- a/boards/sun8i-h3-orangepi-lite/boot.cmd
+++ b/boards/sun8i-h3-orangepi-lite/boot.cmd
@@ -5,12 +5,10 @@
 
 # default values
 setenv load_addr "0x44000000"
-setenv rootdev "/dev/mmcblk0p1"
 setenv verbosity "1"
 setenv console "both"
 setenv disp_mem_reserves "off"
 setenv disp_mode "1920x1080p60"
-setenv rootfstype "ext4"
 
 # Print boot source
 itest.b *0x28 == 0x00 && echo "U-boot loaded from SD"
@@ -30,7 +28,7 @@ if test "${console}" = "serial" || test "${console}" = "both"; then setenv conso
 # mmc 0 is always mapped to device u-boot (2016.09+) was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc 0:1 partuuid; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
+setenv bootargs "${consoleargs} cgroup_enable=memory swapaccount=1 hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} ${extraargs} ${extraboardargs}"
 
 if test "${disp_mem_reserves}" = "off"; then setenv bootargs "${bootargs} sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16"; fi
 


### PR DESCRIPTION
For ramdisk boards, dont specify a filesystem type or partition (fixes #31)