### PR TITLE
Cleanups, Testing and start of generic "XD" support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: enabled
+
+language: c
+
+install:
+    - make build-depends
+    - sudo apt-get install debian-archive-keyring
+
+# See the Ubuntu section in the debian/README file for more details, but this
+# is a good example of why CI is useful /before/ shipping a product..
+#
+# Also, the age of the debian-archive-keyring (2012) is simply concerning. So,
+# I have to manually add the debian stable release keys
+before_script:
+    - sudo sed -i '989s/$forceyes//' /usr/sbin/multistrap
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7638D0442B90D010
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EF0F382A1A7B6500
+
+script:
+    - make test CONFIG_DISABLE_KVM=yes
+
+# TODO
+# - auto deploy the output files to a github release if this is a tagged commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ script:
 
 # TODO
 # - auto deploy the output files to a github release if this is a tagged commit
+# - Push the rendered document svg + pdf output to somewhere

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ all:
 test: image
 	$(MAKE) -C docs
 	@echo Everything builds ok
+	$(MAKE) -C debian test
 
 build-depends clean reallyclean: $(SUBMODULES)
 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) $@ &&) true

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,17 @@ SUBMODULES += debian/Makefile
 all:
 	$(error This Makefile currently has no default build target)
 
+# Perform simple tests that this repository is building correctly
+# TODO
+# - boot up all the emulatable platforms and confirm that they work
+.PHONY: test
+test: image
+	@echo Everything builds ok
+
 build-depends clean reallyclean: $(SUBMODULES)
 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) $@ &&) true
 
+.PHONY: image
 image: $(SUBMODULES)
 	$(foreach dir,$(BOARDDIRS),$(MAKE) -C $(dir) $@ &&) true
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ all:
 # - boot up all the emulatable platforms and confirm that they work
 .PHONY: test
 test: image
+	$(MAKE) -C docs
 	@echo Everything builds ok
 
 build-depends clean reallyclean: $(SUBMODULES)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # A master make file - currently just to help with build-depends and clean
 #
 
+SUBDIRS += docs/
 SUBDIRS += debian/
 SUBDIRS += firmware/
 SUBDIRS += linux/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ QEMUDIRS += boards/qemu_i386/
 SUBDIRS += $(QEMUDIRS)
 
 BOARDDIRS += boards/raspberrypi2/
-BOARDDIRS += boards/sun4i-a10-cubieboard/
+#BOARDDIRS += boards/sun4i-a10-cubieboard/
 BOARDDIRS += boards/sun7i-a20-bananapi/
 BOARDDIRS += boards/sun8i-h2-plus-orangepi-zero/
 BOARDDIRS += boards/sun8i-h3-orangepi-lite/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A small ramdisk system running modern Debian
 This project will create system images for installing a Debian-based
 router.
 
-There are several supported target boards.
+There are several supported target boards - for a quick list, look at
+the subdirectories in the boards directory.  Note that with the standard
+ramdisk confg used (using "tmpfs"), the images will not work with boards
+that have less than 512Meg of RAM.
 
 In the future, it will create a fully working mesh node, with cjdns
 and IPFS software installed.
@@ -17,7 +20,8 @@ There documentory README files in most directories with explanations as
 to what that directory is used for.  These files are located where they
 are so as to stay close to the code and config that they are documenting.
 Be sure to read this main README and all the other ones to get a full view
-of the project.
+of the project.  There are also some diagrams showing some of the build
+process in the docs directory.
 
 
 TOP-GS07 RT5572 WiFi adapter Note
@@ -50,19 +54,34 @@ it will placed in the `output` dir.
 Starting a clean build
 ----------------------
 
-During development, not all the makefile dependancies are always working.
-Whilst this should always be considered a bug, it is important to know
-how to do a clean build from scratch.
+Most of the files in this repository have dependancy tracking, so that
+changing one of them will rebuild just the appropriate parts.  Due to
+the interaction with downloading external packages and building entire
+Debian root dirs, those dependancies do not cover all possible changes.
 
-One simple answer is to completely delete your repository and do a new
-clone from upstream, however that can be a little excessive.  The following
-commands will remove all the build artifacts:
+Therefore, it is sometimes important to "clean" the repository to force
+a full build to be done.  Note though that it should always be considered
+a bug when a missing dependancy is found.
+
+You should never need to completely delete your repository and do a new
+clone from upstream!
+
+There are two different targets provided to clean out the repository:
+
+    make clean
+    make reallyclean
+
+If both are to be run, they should be done in that order, or just combined
+into one command:
 
     make clean reallyclean
 
-The "clean" target removes some files one-by-one from the build dir,
-wheras the "reallyclean" target just nukes each build dir - so this is
-kind of a belt-and-suspender approach.
+The "clean" target trys to remove the minimum set of files to produce
+a clean rebuild.  It trys not to delete any large downloads, thus
+speeding up the following build.  It also takes care to use sudo to
+remove some files that will have been created with different owners.
+
+The "reallyclean" target just nukes everything from each build dir.
 
 
 Using the image

--- a/boards/common-partitions.mk
+++ b/boards/common-partitions.mk
@@ -38,7 +38,7 @@ BUILD_DEPENDS += mtools
 define image_file_create
     truncate --size=$$((0x200)) $(DISK_IMAGE).tmp   # skip past the MBR
     date -u "+%FT%TZ" >>$(DISK_IMAGE).tmp           # add a build date
-    git describe --long --dirty >>$(DISK_IMAGE).tmp # and describe the repo
+    git describe --long --dirty --always >>$(DISK_IMAGE).tmp # describe the repo
 endef
 
 # Create the partitions

--- a/boards/common-xd.mk
+++ b/boards/common-xd.mk
@@ -1,0 +1,64 @@
+#
+# Common rules and definitions for building a fully installed, non ramdisk
+# system ("xD" - where "x" is "anything except Ram")
+#
+
+# Note that this make fragment needs to be included /after/ anything that adds
+# more values to the INITRD_PARTS variable, in order to ensure that the
+# dependancies are right when the rule uses that variable below
+
+ifndef INITRD_PARTS
+$(variable INITRD_PARTS needs to be defined)
+endif
+
+# Build a list of all the cpio files comprising our root filesystem
+# We convert from lzma extensions to cpio extensions so we dont need
+# to compress/decompress (the installed system does not use compressed
+# files)
+# We are also a little paranoid and ensure that the first archive
+# to process will be the main debian archive
+#
+CPIO_FILES = $(addsuffix .cpio,$(basename $(DEBIAN).lzma $(filter-out $(DEBIAN).lzma,$(INITRD_PARTS))))
+
+# A default disk image size that allows boot+swap+root to fit in 1G
+# FIXME
+# - this needs to be equal or smaller than the PART3_SIZE_MEGS!
+PART_SIZE_ROOT_MEGS ?= 700
+
+
+# Note that if we didnt want subvolumes, we could use the
+# mkfs.btrfs "--rootdir" feature that avoids needing suid and loop mount
+
+$(BUILD)/root.fs: $(CPIO_FILES)
+	truncate --size=$$(( $(PART_SIZE_ROOT_MEGS) ))M $@.tmp
+	mkfs.btrfs -L root $@.tmp
+	mkdir -p $@.dir
+	sudo mount -o loop $@.tmp $@.dir
+	sudo btrfs subvolume create $@.dir/@.orig
+	for i in $(CPIO_FILES); do \
+            cat $$i | ( \
+                cd $@.dir/@.orig; \
+                sudo cpio --make-directories -i; \
+            ); \
+	done
+	sudo mkdir $@.dir/@.orig/btrfs
+	sudo rm $@.dir/@.orig/init.d/01welcome.sh
+	sudo ln -s /init $@.dir/@.orig/sbin/init
+	sudo btrfs subvolume snapshot $@.dir/@.orig/ $@.dir/@/
+	sudo btrfs subvolume set-default $$(sudo btrfs subvolume list $@.dir/ |sort |tail -1 |cut -d" " -f2) $@.dir
+	sudo umount $@.dir
+	mv $@.tmp $@
+
+# TODO
+# boot:
+# mount -o subvolid=5 $device /btrfs
+# btrfs subvolume delete /btrfs/@.current/
+# mv /btrfs/@ /btrfs/@.current
+# btrfs subvolume snapshot /btrfs/@.orig/ /btrfs/@.new
+# ID=$(btrfs subvolume list /btrfs/ |grep @.new |cut -d" " -f2)
+# sudo btrfs subvolume set-default $ID /btrfs
+# mv /btrfs/@.new /btrfs/@
+# umount /btrfs
+
+# TODO
+# - cleanup

--- a/boards/raspberrypi2/Makefile
+++ b/boards/raspberrypi2/Makefile
@@ -73,15 +73,16 @@ $(BOOT)/initrd: $(TAG)/boot
 $(BOOT)/initrd: $(BUILD)/combined.initrd
 	cp $< $@
 
-$(BOOT)/cmdline.txt: $(TAG)/boot Makefile
-	echo "dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 elevator=deadline" >$@
+$(BOOT)/cmdline.txt: $(TAG)/boot
+$(BOOT)/cmdline.txt: cmdline.txt
+	cp $< $@
 
-$(BOOT)/config.txt: $(TAG)/boot Makefile
-	echo "" >$@
-	echo "initramfs initrd followkernel" >>$@
-	echo "gpu_mem=16" >>$@
-	echo "enable_uart=1" >>$@
-	echo "dtdebug=1" >>$@
+$(BOOT)/config.txt: $(TAG)/boot
+$(BOOT)/config.txt: config.txt
+	cp $< $@
+
+# TODO
+# - add and enable the pi3-miniuart-bt and pi3-disable-bt overlay files
 
 $(BOOT)/%: $(RASPBERRYPI)/boot/% $(TAG)/boot
 	cp $< $@

--- a/boards/raspberrypi2/Makefile
+++ b/boards/raspberrypi2/Makefile
@@ -35,6 +35,7 @@ include $(TOP_DIR)/mk/common-raspbian.mk
 include $(TOP_DIR)/boards/common-cjdns-hack.mk
 include $(TOP_DIR)/boards/common-initrd.mk
 
+# TODO - convert this to using the image target defined in mk/common.mk
 image: $(TOP_DIR)/output/$(BOARD).img
 
 $(TOP_DIR)/output/$(BOARD).img: $(DISK_IMAGE)

--- a/boards/raspberrypi2/Makefile
+++ b/boards/raspberrypi2/Makefile
@@ -35,13 +35,12 @@ include $(TOP_DIR)/mk/common-raspbian.mk
 include $(TOP_DIR)/boards/common-cjdns-hack.mk
 include $(TOP_DIR)/boards/common-initrd.mk
 
-# TODO - convert this to using the image target defined in mk/common.mk
-image: $(TOP_DIR)/output/$(BOARD).img
+# Add the alias to the normal image target
+image: $(TOP_DIR)/output/$(BOARD_ALIAS).img
 
-$(TOP_DIR)/output/$(BOARD).img: $(DISK_IMAGE)
-	mkdir -p $(dir $@)
+$(TOP_DIR)/output/$(BOARD_ALIAS).img: $(DISK_IMAGE)
+	@mkdir -p $(dir $@)
 	cp $< $@
-	cp $< $(TOP_DIR)/output/$(BOARD_ALIAS).img
 
 test:
 	echo this board must be tested by flashing the output

--- a/boards/raspberrypi2/README.md
+++ b/boards/raspberrypi2/README.md
@@ -6,6 +6,9 @@ Compute Module 1, Raspberry Pi 1A or Raspberry Pi 1B boards without major
 changes to the debian-minimal-builder submodule - this is due to hardware
 incompatibilities and is unlikely to change.
 
+It should be possible to support the Raspberry Pi 3B+, however we need
+some testing to confirm that.
+
 Supported Boards
 ----------------
 

--- a/boards/raspberrypi2/cmdline.txt
+++ b/boards/raspberrypi2/cmdline.txt
@@ -1,0 +1,1 @@
+dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 elevator=deadline

--- a/boards/raspberrypi2/cmdline.txt
+++ b/boards/raspberrypi2/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 elevator=deadline
+dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=ttyS0,115200

--- a/boards/raspberrypi2/config.txt
+++ b/boards/raspberrypi2/config.txt
@@ -1,0 +1,5 @@
+
+initramfs initrd followkernel
+gpu_mem=16
+enable_uart=1
+dtdebug=1

--- a/boards/sun4i-a10-cubieboard/Makefile
+++ b/boards/sun4i-a10-cubieboard/Makefile
@@ -34,10 +34,6 @@ include $(TOP_DIR)/mk/common-armbian.mk
 include $(TOP_DIR)/boards/common-cjdns-hack.mk
 include $(TOP_DIR)/boards/common-initrd.mk
 
-image: $(DISK_IMAGE)
-	mkdir -p $(TOP_DIR)/output
-	cp $< $(TOP_DIR)/output/$(BOARD).img
-
 test:
 	echo this board must be tested by flashing the output
 	false

--- a/boards/sun7i-a20-bananapi/Makefile
+++ b/boards/sun7i-a20-bananapi/Makefile
@@ -34,10 +34,6 @@ include $(TOP_DIR)/mk/common-armbian.mk
 include $(TOP_DIR)/boards/common-cjdns-hack.mk
 include $(TOP_DIR)/boards/common-initrd.mk
 
-image: $(DISK_IMAGE)
-	mkdir -p $(TOP_DIR)/output
-	cp $< $(TOP_DIR)/output/$(BOARD).img
-
 test:
 	echo this board must be tested by flashing the output
 	false

--- a/boards/sun7i-a20-bananapi/Makefile
+++ b/boards/sun7i-a20-bananapi/Makefile
@@ -7,7 +7,7 @@ DEBIAN_ARCH = armhf
 
 # which uboot and device tree is this being built for
 ARMBIAN_UBOOT_PKG = linux-u-boot-bananapi-dev
-UBOOT = linux-u-boot-dev-bananapi_5.31_armhf
+UBOOT = linux-u-boot-dev-bananapi_5.38_armhf
 BOARD = sun7i-a20-bananapi
 # FIXME - it would be nice if the uboot name was related to the dtb name
 

--- a/boards/sun8i-h2-plus-orangepi-zero/Makefile
+++ b/boards/sun8i-h2-plus-orangepi-zero/Makefile
@@ -34,10 +34,6 @@ include $(TOP_DIR)/mk/common-armbian.mk
 include $(TOP_DIR)/boards/common-cjdns-hack.mk
 include $(TOP_DIR)/boards/common-initrd.mk
 
-image: $(DISK_IMAGE)
-	mkdir -p $(TOP_DIR)/output
-	cp $< $(TOP_DIR)/output/$(BOARD).img
-
 test:
 	echo this board must be tested by flashing the output
 	false

--- a/boards/sun8i-h3-orangepi-lite/Makefile
+++ b/boards/sun8i-h3-orangepi-lite/Makefile
@@ -40,10 +40,6 @@ include $(TOP_DIR)/mk/common-armbian.mk
 include $(TOP_DIR)/boards/common-cjdns-hack.mk
 include $(TOP_DIR)/boards/common-initrd.mk
 
-image: $(DISK_IMAGE)
-	mkdir -p $(TOP_DIR)/output
-	cp $< $(TOP_DIR)/output/$(BOARD).img
-
 test:
 	echo this board must be tested by flashing the output
 	false

--- a/boards/sun8i-h3-orangepi-lite/Makefile
+++ b/boards/sun8i-h3-orangepi-lite/Makefile
@@ -7,8 +7,8 @@ DEBIAN_ARCH = armhf
 
 # which uboot and device tree is this being built for
 ARMBIAN_UBOOT_PKG = linux-u-boot-orangepilite-dev
-ARMBIAN_KERNEL_PKG = linux-image-dev-sun8i=5.26
-UBOOT = linux-u-boot-dev-orangepilite_5.31_armhf
+ARMBIAN_KERNEL_PKG = linux-image-dev-sun8i=5.35
+UBOOT = linux-u-boot-dev-orangepilite_5.38_armhf
 BOARD = sun8i-h3-orangepi-lite
 # FIXME - it would be nice if the uboot name was related to the dtb name
 
@@ -104,7 +104,8 @@ $(TAG)/dtbo: $(TAG)/dtb
 	$(call tag,dtbo)
 
 $(BOOT)/dtb/overlay/%.dtbo: $(TAG)/armbian $(TAG)/dtbo
-	cp $< $@
+	touch $@ # FIXME
+	#cp $< $@
 
 $(BOOT)/uInitrd: $(TAG)/boot
 $(BOOT)/uInitrd: $(BUILD)/combined.uInitrd

--- a/boards/sun8i-v3s-licheepi-zero/Makefile
+++ b/boards/sun8i-v3s-licheepi-zero/Makefile
@@ -36,10 +36,11 @@ include $(TOP_DIR)/mk/common.mk
 include $(TOP_DIR)/boards/common-partitions.mk
 include $(TOP_DIR)/boards/common-allwinner.mk
 include $(TOP_DIR)/boards/common-kernel-local.mk
+include $(TOP_DIR)/boards/common-xd.mk
 
 image: $(DISK_IMAGE)
 	mkdir -p $(TOP_DIR)/output
-	cp $< $(TOP_DIR)/output/$(BOARD).img
+	cp $< $(TOP_DIR)/output/$(BOARD).xd.img
 
 test:
 	echo this board must be tested by flashing the output
@@ -61,25 +62,6 @@ $(ZERO_FIRMWARE): $(ZIP)
 	    find lib/firmware -print0 | cpio -0 -H newc -R 0:0 -o \
 	) >$@
 CLEAN_FILES += $(ZERO_FIRMWARE)
-
-$(BUILD)/root.fs: $(DEBIAN).cpio $(LOCAL_MODULES_CPIO) $(ZIP)
-	truncate --size=$$(( $(PART3_SIZE_MEGS)*1 ))M $@.tmp
-	/sbin/mkfs.ext4 -L root $@.tmp
-	mkdir -p $@.dir
-	sudo mount -oloop $@.tmp $@.dir
-	cat $(DEBIAN).cpio | ( \
-            cd $@.dir; \
-            sudo cpio --make-directories -i; \
-	)
-	sudo rm $@.dir/init.d/01welcome.sh
-	sudo ln -s /init $@.dir/sbin/init
-	cat $(LOCAL_MODULES_CPIO) | ( \
-            cd $@.dir; \
-            sudo cpio --make-directories -i; \
-	)
-	sudo cp -r $(ZIP)/overlay_rootfs-base/lib/firmware/ $@.dir/lib/firmware/
-	sudo umount $@.dir
-	mv $@.tmp $@
 
 $(BOOT): $(TAG)/boot
 $(TAG)/boot:
@@ -128,6 +110,9 @@ $(DISK_IMAGE): $(SRC_SPL) $(BUILD)/mtoolsrc $(BOOT_FILES) $(BOOT_DTB_FILES) $(BU
 
 # Misc make infrastructure below here
 
+# TODO
+# - improve the normal clean target to handle the root.fs.dir
+# - move the root.fs.dir stuff into the common-xd.mk file
 clean:
 	rm -rf $(CLEAN_FILES)
 	sudo rm -rf $(BUILD)/root.fs.dir

--- a/boards/sun8i-v3s-licheepi-zero/Makefile
+++ b/boards/sun8i-v3s-licheepi-zero/Makefile
@@ -38,10 +38,6 @@ include $(TOP_DIR)/boards/common-allwinner.mk
 include $(TOP_DIR)/boards/common-kernel-local.mk
 include $(TOP_DIR)/boards/common-xd.mk
 
-image: $(DISK_IMAGE)
-	mkdir -p $(TOP_DIR)/output
-	cp $< $(TOP_DIR)/output/$(BOARD).xd.img
-
 test:
 	echo this board must be tested by flashing the output
 	false

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+
+# Ignore generated output
+*.pdf
+*.svg

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,19 @@
+#
+# A simple way to get all the diagrams as SVG
+#
+
+DIAGRAMS := boot-1 boot-2 \
+    build kernel debian_minimal_builder \
+
+all: $(addsuffix .svg,$(DIAGRAMS))
+all: $(addsuffix .pdf,$(DIAGRAMS))
+
+clean:
+	rm -f $(addsuffix .svg,$(DIAGRAMS))  $(addsuffix .pdf,$(DIAGRAMS))
+
+%.svg: %.dot
+	dot -Tsvg >$@ $<
+
+%.pdf: %.dot
+	dot -Tpdf >$@ $<
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,6 +8,9 @@ DIAGRAMS := boot-1 boot-2 \
 all: $(addsuffix .svg,$(DIAGRAMS))
 all: $(addsuffix .pdf,$(DIAGRAMS))
 
+build-depends:
+	sudo apt install graphviz
+
 clean:
 	rm -f $(addsuffix .svg,$(DIAGRAMS))  $(addsuffix .pdf,$(DIAGRAMS))
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -30,7 +30,7 @@ Update with new Config (if needed):
     make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- nconfig
 
 Build:
-    make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- -j2 zImage LOADADDR=0x42000000 dtbs modules
+    make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- -j2 LOADADDR=0x42000000 zImage modules dtbs
 
 Install into build dir:
     LINUX=$PWD/linux
@@ -41,14 +41,17 @@ Install into build dir:
     mkdir -p $BUILD/dtb
     cp arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dtb $BUILD/dtb
     cp arch/arm/boot/dts/sun7i-a20-bananapi.dtb $BUILD/dtb
-    cp arch/arm/boot/dts/sun4i-a10-cubieboard.dtb $BUILD/dtb
     cp arch/arm/boot/zImage $BUILD/
     cp .config $BUILD/
+    mkdir -p $BUILD/lib/modules
     make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- \
         INSTALL_MOD_PATH=$BUILD/ modules_install
     rm -f $BUILD/lib/modules/*/build
     rm -f $BUILD/lib/modules/*/source
+    # Ensure the build system doesnt download/unpack the old bundle
+    touch --date="jan 1 1990" $BUILD/linux-armhf.tar.xz
 
+After testing, make a bundle - ready to upload to a github release
 Bundle:
     tar -C build -cJf build/linux-armhf.tar.xz linux-armhf
 
@@ -64,6 +67,7 @@ bananapi:
     video out / audio out - untested, not needed in a router build
 
 cubieboard:
+    Kernel support disabled - this is a very old board!
     cpufreq not working
     USB OTG not working
     NAND not detected

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,5 +1,5 @@
 #
-# functions and definitions expected to be used my many or all systems
+# functions and definitions expected to be used by many or all systems
 #
 
 # Calculate the basename of the debian build file
@@ -18,6 +18,11 @@ TAG = $(BUILD)/tags
 BOOT = $(BUILD)/boot
 
 DISK_IMAGE = $(BUILD)/disk.img
+
+.PHONY: image
+image: $(DISK_IMAGE)
+	@mkdir -p $(TOP_DIR)/output
+	cp $< $(TOP_DIR)/output/$(BOARD).img
 
 # install any packages needed for the builder
 build-depends: $(TAG)/build-depends


### PR DESCRIPTION
- Documentation clarifications (Including recent discovery that we now needed >256Meg)
- More centralisation of generic boards code
- Discover some boards have bit-rotted and needed fixing
  - Add a CI framework to ensure this doesn't happen unnoticed in the future
- Start to add the meat of the non ramdisk "xd" filesystem creator.