### PR TITLE
FIX Build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_script:
 
 script:
     - make test CONFIG_DISABLE_KVM=yes
+    - sha1sum output/*
+    - ls -al output/*
 
 # TODO
 # - auto deploy the output files to a github release if this is a tagged commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: c
 
 install:
     - make build-depends
-    - sudo apt-get install debian-archive-keyring
+    - sudo apt-get -y install debian-archive-keyring dpkg=1.17.5ubuntu5.8
 
 # See the Ubuntu section in the debian/README file for more details, but this
 # is a good example of why CI is useful /before/ shipping a product..


### PR DESCRIPTION
It seems that Armbian have updated some of their older published packages to use XZ compression.  This breaks dpkg with the version of Ubuntu (14.04) used by the TravisCI.

I'm a little astonished that Armbian have made breaking changes to previously published (and theortically change-frozen) packages!  There is no technical reason to make any changes without bumping the version number - the Debian package version format even has a number of features suitable for that kind of change!